### PR TITLE
Add security QA procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ You can create a lightweight PRD directly within Cursor:
 
 With your PRD drafted (e.g., `MyFeature-PRD.md`), the next step is to generate a detailed, step-by-step implementation plan for your AI Developer.
 
-1.  Ensure you have `generate-tasks-from-prd.mdc` accessible.
+1.  Ensure you have `generate-tasks.mdc` accessible.
 2.  In Cursor's Agent chat, use the PRD to create tasks:
 
     ```
-    Now take @MyFeature-PRD.md and create tasks using @generate-tasks-from-prd.mdc
+    Now take @MyFeature-PRD.md and create tasks using @generate-tasks.mdc
     ```
     *(Note: Replace `@MyFeature-PRD.md` with the actual filename of the PRD you generated in step 1.)*
 
@@ -87,8 +87,9 @@ While it's not always perfect, this method has proven to be a very reliable way 
 ## 🗂️ Files in this Repository
 
 *   **`create-prd.mdc`**: Guides the AI in generating a Product Requirement Document for your feature.
-*   **`generate-tasks-from-prd.mdc`**: Takes a PRD markdown file as input and helps the AI break it down into a detailed, step-by-step implementation task list.
-*   **`process-task-list.mdc`**: Instructs the AI on how to process the generated task list, tackling one task at a time and waiting for your approval before proceeding. (This file also contains logic for the AI to mark tasks as complete).
+*   **`generate-tasks.mdc`**: Takes a PRD markdown file as input and helps the AI break it down into a detailed, step-by-step implementation task list with embedded QA and security subtasks.
+*   **`process-task-list.mdc`**: Instructs the AI on how to process the generated task list, tackling one task at a time and waiting for your approval before proceeding. This file also checks for QA sign-off and passing security scans before closing tasks.
+*   **`generate-qa-checklist.mdc`**: Builds a feature-specific QA checklist covering accessibility, security scans, and coverage requirements.
 
 ## 🌟 Benefits
 

--- a/create-prd.mdc
+++ b/create-prd.mdc
@@ -28,7 +28,10 @@ The AI should adapt its questions based on the prompt, but here are some common 
 *   **Scope/Boundaries:** "Are there any specific things this feature *should not* do (non-goals)?"
 *   **Data Requirements:** "What kind of data does this feature need to display or manipulate?"
 *   **Design/UI:** "Are there any existing design mockups or UI guidelines to follow?" or "Can you describe the desired look and feel?"
-*   **Edge Cases:** "Are there any potential edge cases or error conditions we should consider?"
+*   **QA Acceptance Criteria:** "What QA acceptance criteria must this feature satisfy?"
+*   **Non‑Negotiable QA Commandments:** "Are there any absolute quality rules that cannot be compromised?"
+*   **Edge Case Enumeration:** "Can you list potential edge cases or error conditions we should test for?"
+*   **Security Considerations:** "Are there specific security requirements like rate limiting or file validation we must enforce?"
 
 ## PRD Structure
 
@@ -39,10 +42,15 @@ The generated PRD should include the following sections:
 3.  **User Stories:** Detail the user narratives describing feature usage and benefits.
 4.  **Functional Requirements:** List the specific functionalities the feature must have. Use clear, concise language (e.g., "The system must allow users to upload a profile picture."). Number these requirements.
 5.  **Non-Goals (Out of Scope):** Clearly state what this feature will *not* include to manage scope.
-6.  **Design Considerations (Optional):** Link to mockups, describe UI/UX requirements, or mention relevant components/styles if applicable.
-7.  **Technical Considerations (Optional):** Mention any known technical constraints, dependencies, or suggestions (e.g., "Should integrate with the existing Auth module").
-8.  **Success Metrics:** How will the success of this feature be measured? (e.g., "Increase user engagement by 10%", "Reduce support tickets related to X").
-9.  **Open Questions:** List any remaining questions or areas needing further clarification.
+6.  **QA Acceptance Criteria:** Provide a checklist of conditions the feature must meet to pass QA.
+7.  **Non‑Negotiable QA Commandments:** Bullet list of absolute quality rules that cannot be broken.
+8.  **Edge Case Enumeration:** List potential edge cases to test.
+9.  **Quality Assurance Plan:** Link to `QA_WORKFLOW.md` for the detailed QA process.
+10. **Security Considerations:** Bullet list security requirements like rate limiting, invalid input handling, and file validation.
+11. **Design Considerations (Optional):** Link to mockups, describe UI/UX requirements, or mention relevant components/styles if applicable.
+12. **Technical Considerations (Optional):** Mention any known technical constraints, dependencies, or suggestions (e.g., "Should integrate with the existing Auth module").
+13. **Success Metrics:** How will the success of this feature be measured? (e.g., "Increase user engagement by 10%", "Reduce support tickets related to X").
+14. **Open Questions:** List any remaining questions or areas needing further clarification.
 
 ## Target Audience
 
@@ -59,3 +67,4 @@ Assume the primary reader of the PRD is a **junior developer**. Therefore, requi
 1. Do NOT start implementing the PRD
 2. Make sure to ask the user clarifying questions
 3. Take the user's answers to the clarifying questions and improve the PRD
+4. **Do not proceed to generate tasks until the QA and security sections are clearly defined.**

--- a/generate-qa-checklist.mdc
+++ b/generate-qa-checklist.mdc
@@ -1,0 +1,27 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+# Generate QA Checklist
+
+## Goal
+Create a detailed QA checklist for a specific feature based on its PRD and task list.
+
+## Process
+1. Determine the feature type (API, UI, DB, etc.) and highlight unique QA risks.
+2. Include checklist items for:
+   - Unit tests (>=90% coverage)
+   - Integration tests (>=80% coverage)
+   - At least one end-to-end test for each user flow
+   - Accessibility audit using axe-core, Lighthouse, or pa11y (score must be 90 or higher)
+   - Security scans with OWASP ZAP or Snyk
+   - Rate limit enforcement
+   - Invalid input handling
+   - File upload validation
+   - Logging and error handling
+3. Provide manual test steps and expected results.
+4. Leave fields for the reviewer name and date.
+
+## Output Format
+The checklist should be saved as `[feature-name]-qa-checklist.md` in the `/tasks/` directory.

--- a/generate-tasks.mdc
+++ b/generate-tasks.mdc
@@ -21,9 +21,9 @@ To guide an AI assistant in creating a detailed, step-by-step task list in Markd
 2.  **Analyze PRD:** The AI reads and analyzes the functional requirements, user stories, and other sections of the specified PRD.
 3.  **Phase 1: Generate Parent Tasks:** Based on the PRD analysis, create the file and generate the main, high-level tasks required to implement the feature. Use your judgement on how many high-level tasks to use. It's likely to be about 5. Present these tasks to the user in the specified format (without sub-tasks yet). Inform the user: "I have generated the high-level tasks based on the PRD. Ready to generate the sub-tasks? Respond with 'Go' to proceed."
 4.  **Wait for Confirmation:** Pause and wait for the user to respond with "Go".
-5.  **Phase 2: Generate Sub-Tasks:** Once the user confirms, break down each parent task into smaller, actionable sub-tasks necessary to complete the parent task. Ensure sub-tasks logically follow from the parent task and cover the implementation details implied by the PRD.
-6.  **Identify Relevant Files:** Based on the tasks and PRD, identify potential files that will need to be created or modified. List these under the `Relevant Files` section, including corresponding test files if applicable.
-7.  **Generate Final Output:** Combine the parent tasks, sub-tasks, relevant files, and notes into the final Markdown structure.
+5.  **Phase 2: Generate Sub-Tasks:** Once the user confirms, break down each parent task into smaller, actionable sub-tasks necessary to complete the parent task. Ensure sub-tasks logically follow from the parent task and cover the implementation details implied by the PRD. For each feature task, automatically create QA subtasks covering unit tests, manual verification, CI checks, edge case validation, accessibility scanning (axe-core, Lighthouse, or pa11y) with a score requirement of 90 or higher, and security scanning using OWASP ZAP or Snyk. Tag these subtasks with `qa-required`.
+6.  **Identify Relevant Files:** Based on the tasks and PRD, identify potential files that will need to be created or modified. List these under the `Relevant Files` section, including corresponding test files, security test scripts, and configuration files for security tools if applicable.
+7.  **Generate Final Output:** Combine the parent tasks, sub-tasks, relevant files, and notes into the final Markdown structure. Include checklist items for rate limit enforcement, invalid input handling, and file upload validation.
 8.  **Save Task List:** Save the generated document in the `/tasks/` directory with the filename `tasks-[prd-file-name].md`, where `[prd-file-name]` matches the base name of the input PRD file (e.g., if the input was `prd-user-profile-editing.md`, the output is `tasks-prd-user-profile-editing.md`).
 
 ## Output Format
@@ -44,6 +44,7 @@ The generated task list _must_ follow this structure:
 
 - Unit tests should typically be placed alongside the code files they are testing (e.g., `MyComponent.tsx` and `MyComponent.test.tsx` in the same directory).
 - Use `npx jest [optional/path/to/test/file]` to run tests. Running without a path executes all tests found by the Jest configuration.
+- Security scans (OWASP ZAP/Snyk) must pass before merging. Block the merge if vulnerabilities are found.
 
 ## Tasks
 

--- a/process-task-list.mdc
+++ b/process-task-list.mdc
@@ -36,3 +36,4 @@ When working with task lists, the AI must:
 4. Keep “Relevant Files” accurate and up to date.
 5. Before starting work, check which sub‑task is next.
 6. After implementing a sub‑task, update the file and then pause for user approval.
+7. Before marking a task complete, confirm that all QA subtasks are finished, security scans pass with no critical issues, and coverage requirements are met. Ask the user explicitly: "Has QA signed off on this task?". If not, do not mark it complete.


### PR DESCRIPTION
## Summary
- prompt for security considerations in PRD creation
- inject security and accessibility checks into task generation
- enforce QA sign-off and scans before closing tasks
- document new workflow files and update README references

## Testing
- `pytest -q`