### PR TITLE
Add QA summary docs, tests, and regression builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ You can create a lightweight PRD directly within Cursor:
 
 With your PRD drafted (e.g., `MyFeature-PRD.md`), the next step is to generate a detailed, step-by-step implementation plan for your AI Developer.
 
-1.  Ensure you have `generate-tasks-from-prd.mdc` accessible.
+1.  Ensure you have `generate-tasks.mdc` accessible.
 2.  In Cursor's Agent chat, use the PRD to create tasks:
 
     ```
-    Now take @MyFeature-PRD.md and create tasks using @generate-tasks-from-prd.mdc
+    Now take @MyFeature-PRD.md and create tasks using @generate-tasks.mdc
     ```
     *(Note: Replace `@MyFeature-PRD.md` with the actual filename of the PRD you generated in step 1.)*
 
@@ -87,8 +87,10 @@ While it's not always perfect, this method has proven to be a very reliable way 
 ## 🗂️ Files in this Repository
 
 *   **`create-prd.mdc`**: Guides the AI in generating a Product Requirement Document for your feature.
-*   **`generate-tasks-from-prd.mdc`**: Takes a PRD markdown file as input and helps the AI break it down into a detailed, step-by-step implementation task list.
+*   **`generate-tasks.mdc`**: Takes a PRD markdown file as input and helps the AI break it down into a detailed, step-by-step implementation task list.
 *   **`process-task-list.mdc`**: Instructs the AI on how to process the generated task list, tackling one task at a time and waiting for your approval before proceeding. (This file also contains logic for the AI to mark tasks as complete).
+*   **`qa-regression-builder.mdc`**: After a merge, parse logs for repeated errors and suggest regression tests or new tasks.
+*   **`scripts/generate_qa_summary.py`**: Creates a `qa-summary.md` file summarizing tasks, QA reviewers, test coverage, bugs, and CI/CD logs.
 
 ## 🌟 Benefits
 
@@ -112,6 +114,17 @@ While it's not always perfect, this method has proven to be a very reliable way 
 *   **MAX Mode for PRDs:** As mentioned, using MAX mode in Cursor for PRD creation (`create-prd.mdc`) can yield more thorough and higher-quality results if your budget supports it.
 *   **Correct File Tagging:** Always ensure you're accurately tagging the PRD filename (e.g., `@MyFeature-PRD.md`) when generating tasks.
 *   **Patience and Iteration:** AI is a powerful tool, but it's not magic. Be prepared to guide, correct, and iterate. This workflow is designed to make that iteration process smoother.
+## QA Report Generation & Traceability
+
+Use `scripts/generate_qa_summary.py` to produce a `qa-summary.md` for each PR. Provide the task list file, QA reviewer names, test coverage results, bug information, and CI/CD log URL. Commit the generated summary for audit purposes.
+```bash
+python3 scripts/generate_qa_summary.py --tasks-file tasks-example.md 
+    --qa-reviewers "Alice,Bob" --test-coverage coverage.txt 
+    --bugs-fixed bugs.txt --cicd-log-url https://link.to/logs
+```
+This creates `qa-summary.md`.
+
+
 
 ## 🤝 Contributing
 

--- a/qa-regression-builder.mdc
+++ b/qa-regression-builder.mdc
@@ -1,0 +1,38 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+# QA Regression Builder
+
+Guidance for analyzing logs after a merge to discover recurring issues and propose regression tests or follow-up tasks.
+
+## Goal
+
+Use Cursor to parse logs or test reports for repeated errors or anomalies and turn those findings into actionable QA items.
+
+## Process
+
+1. **Provide Log Sources:** The user supplies log files or links to CI reports.
+2. **Analyze for Patterns:** Scan the logs for repeated stack traces, error messages, or unusual failures.
+3. **Summarize Findings:** List each unique issue with a brief description.
+4. **Suggest Regression Tests:** For each issue, propose a regression test case and any necessary updates to the QA checklist.
+5. **Create Optional Tasks:** If problems remain unresolved, generate new tasks tagged `qa-regression` in the related task list.
+6. **Output Results:** Present a short report that includes proposed tests, checklist changes, and tasks.
+
+## Output Format
+
+```markdown
+### Regression Issues Found
+- *Error summary 1* — Suggested regression test or checklist update
+- *Error summary 2* — Suggested regression test or checklist update
+
+### Suggested Tasks
+- [ ] Investigate and fix *error summary 1*
+- [ ] Add regression test for *error summary 1*
+```
+
+## Target Audience
+
+QA engineers and developers looking to strengthen test coverage based on real-world failures.
+

--- a/scripts/generate_qa_summary.py
+++ b/scripts/generate_qa_summary.py
@@ -1,0 +1,107 @@
+"""Utility for creating a markdown QA summary file for compliance audits."""
+
+import argparse
+import re
+from pathlib import Path
+
+
+def parse_tasks(path: Path):
+    """Parse a markdown task list.
+
+    Parameters
+    ----------
+    path : Path
+        Path to the markdown file containing a ``## Tasks`` section.
+
+    Returns
+    -------
+    list[str]
+        Formatted task strings preserving completion status.
+    """
+
+    tasks = []
+    if not path.is_file():
+        return tasks
+    in_tasks_section = False
+    task_pattern = re.compile(r"^\s*- \[( |x)\] \d+\.\d+ (.+)")
+    with path.open() as f:
+        for line in f:
+            if line.strip().lower().startswith("## tasks"):
+                in_tasks_section = True
+                continue
+            if in_tasks_section:
+                if line.strip().startswith("##") and not line.strip().lower().startswith("## tasks"):
+                    break
+                m = task_pattern.match(line)
+                if m:
+                    status = "Done" if m.group(1) == "x" else "Todo"
+                    tasks.append(f"[{status}] {m.group(2).strip()}")
+    return tasks
+
+
+def read_text(path: Path):
+    """Return the contents of ``path`` or an empty string if it doesn't exist."""
+
+    if path and path.is_file():
+        return path.read_text().strip()
+    return ""
+
+
+def generate_summary(args):
+    """Create the QA summary markdown file based on CLI arguments."""
+
+    tasks = parse_tasks(args.tasks_file) if args.tasks_file else []
+    coverage = read_text(args.test_coverage)
+    bugs = read_text(args.bugs_fixed)
+
+    output_lines = [
+        '# QA Summary',
+        '',
+    ]
+
+    if tasks:
+        output_lines.append('## Task Names')
+        for t in tasks:
+            output_lines.append(f'- {t}')
+        output_lines.append('')
+
+    if args.qa_reviewers:
+        output_lines.append('## QA Reviewer(s)')
+        for name in args.qa_reviewers.split(','):
+            output_lines.append(f'- {name.strip()}')
+        output_lines.append('')
+
+    if coverage:
+        output_lines.append('## Test Coverage Results')
+        output_lines.append(coverage)
+        output_lines.append('')
+
+    if bugs:
+        output_lines.append('## Bugs Found / Fixed')
+        output_lines.append(bugs)
+        output_lines.append('')
+
+    if args.cicd_log_url:
+        output_lines.append('## CI/CD Logs')
+        output_lines.append(args.cicd_log_url)
+        output_lines.append('')
+
+    Path(args.output).write_text("\n".join(output_lines))
+
+
+def main():
+    """Entry point for the ``generate_qa_summary.py`` command line interface."""
+
+    parser = argparse.ArgumentParser(description="Generate qa-summary.md for compliance audits")
+    parser.add_argument('--tasks-file', type=Path, help='Path to tasks markdown file')
+    parser.add_argument('--qa-reviewers', help='Comma-separated list of QA reviewer names')
+    parser.add_argument('--test-coverage', type=Path, help='Path to test coverage results file')
+    parser.add_argument('--bugs-fixed', type=Path, help='Path to bugs found/fixed file')
+    parser.add_argument('--cicd-log-url', help='Link to CI/CD logs')
+    parser.add_argument('--output', default='qa-summary.md', help='Output markdown file')
+    args = parser.parse_args()
+    generate_summary(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_generate_qa_summary.py
+++ b/tests/test_generate_qa_summary.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import argparse
+
+from scripts.generate_qa_summary import parse_tasks, generate_summary
+
+
+def test_parse_tasks(tmp_path):
+    md = tmp_path / "tasks.md"
+    md.write_text(
+        """## Tasks\n- [ ] 1.1 Setup env\n- [x] 1.2 Implement feature\n- [ ] 2.1 Write tests\n"""
+    )
+    tasks = parse_tasks(md)
+    assert tasks == [
+        "[Todo] Setup env",
+        "[Done] Implement feature",
+        "[Todo] Write tests",
+    ]
+
+
+def test_generate_summary(tmp_path):
+    tasks_file = tmp_path / "tasks.md"
+    tasks_file.write_text("## Tasks\n- [ ] 1.1 Do stuff\n")
+    coverage = tmp_path / "coverage.txt"
+    coverage.write_text("85%")
+    bugs = tmp_path / "bugs.txt"
+    bugs.write_text("None")
+    output = tmp_path / "out.md"
+
+    args = argparse.Namespace(
+        tasks_file=tasks_file,
+        qa_reviewers="Alice,Bob",
+        test_coverage=coverage,
+        bugs_fixed=bugs,
+        cicd_log_url="http://ci.example", 
+        output=output,
+    )
+
+    generate_summary(args)
+    content = output.read_text()
+
+    assert "# QA Summary" in content
+    assert "Alice" in content and "Bob" in content
+    assert "85%" in content
+    assert "None" in content


### PR DESCRIPTION
## Summary
- add `qa-regression-builder.mdc` back to repo
- document QA summary script and regression builder in README
- provide usage example for `generate_qa_summary.py`
- add docstrings to summary script
- create tests for summary generation

## Testing
- `pytest -q`
- `python3 scripts/generate_qa_summary.py -h`