### PR TITLE
Remove stray tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,19 +96,15 @@ After merging your changes, run `qa-regression-builder.mdc` to analyze recent lo
 ## 🗂️ Files in this Repository
 
 *   **`create-prd.mdc`**: Guides the AI in generating a Product Requirement Document for your feature.
-codex/update-prd-with-qa-sections-and-checklist
 *   **`generate-tasks.mdc`**: Takes a PRD markdown file as input and helps the AI break it down into a detailed, step-by-step implementation task list with embedded QA and security subtasks.
 *   **`process-task-list.mdc`**: Instructs the AI on how to process the generated task list, tackling one task at a time and waiting for your approval before proceeding. This file also checks for QA sign-off and passing security scans before closing tasks.
 *   **`generate-qa-checklist.mdc`**: Builds a feature-specific QA checklist covering accessibility, security scans, and coverage requirements.
 *   **`qa-regression-builder.mdc`**: After a merge, parse logs for repeated errors and suggest regression tests or new tasks.
-main
 
 *   **`generate-tasks.mdc`**: Takes a PRD markdown file as input and helps the AI break it down into a detailed, step-by-step implementation task list.
 *   **`process-task-list.mdc`**: Instructs the AI on how to process the generated task list, tackling one task at a time and waiting for your approval before proceeding. (This file also contains logic for the AI to mark tasks as complete).
- codex/auto-generate-qa-summary.md-per-feature/pr
 *   **`scripts/generate_qa_summary.py`**: Creates a `qa-summary.md` file summarizing tasks, QA reviewers, test coverage, bugs, and CI/CD logs.
 *   **`qa-regression-builder.mdc`**: After a merge, parse logs for repeated errors and suggest regression tests or new tasks.
- main
  
 
 ## 🌟 Benefits
@@ -136,7 +132,6 @@ main
 ## QA Report Generation & Traceability
 
 Use `scripts/generate_qa_summary.py` to produce a `qa-summary.md` for each PR. Provide the task list file, QA reviewer names, test coverage results, bug information, and CI/CD log URL. Commit the generated summary for audit purposes.
-codex/auto-generate-qa-summary.md-per-feature/pr
 
 
 ```bash
@@ -157,7 +152,6 @@ For projects requiring deeper upfront analysis, consult the **[Advanced Business
 3. Break down the chosen option into a detailed design document for user review and approval.
 4. Embed QA activities in every step to achieve full functional test coverage.
 
-main
 
 ## 🤝 Contributing
 

--- a/create-prd.mdc
+++ b/create-prd.mdc
@@ -31,9 +31,7 @@ The AI should adapt its questions based on the prompt, but here are some common 
 *   **QA Acceptance Criteria:** "What QA acceptance criteria must this feature satisfy?"
 *   **Non‑Negotiable QA Commandments:** "Are there any absolute quality rules that cannot be compromised?"
 *   **Edge Case Enumeration:** "Can you list potential edge cases or error conditions we should test for?"
- codex/update-prd-with-qa-sections-and-checklist
 *   **Security Considerations:** "Are there specific security requirements like rate limiting or file validation we must enforce?"
- main
 
 ## PRD Structure
 
@@ -48,7 +46,6 @@ The generated PRD should include the following sections:
 7.  **Non‑Negotiable QA Commandments:** Bullet list of absolute quality rules that cannot be broken.
 8.  **Edge Case Enumeration:** List potential edge cases to test.
 9.  **Quality Assurance Plan:** Link to `QA_WORKFLOW.md` for the detailed QA process.
- codex/update-prd-with-qa-sections-and-checklist
 10. **Security Considerations:** Bullet list security requirements like rate limiting, invalid input handling, and file validation.
 11. **Design Considerations (Optional):** Link to mockups, describe UI/UX requirements, or mention relevant components/styles if applicable.
 12. **Technical Considerations (Optional):** Mention any known technical constraints, dependencies, or suggestions (e.g., "Should integrate with the existing Auth module").
@@ -72,4 +69,3 @@ Assume the primary reader of the PRD is a **junior developer**. Therefore, requi
 2. Make sure to ask the user clarifying questions
 3. Take the user's answers to the clarifying questions and improve the PRD
 4. Do not proceed to generate tasks until the QA and security sections are clearly defined.
-main

--- a/scripts/generate_qa_summary.py
+++ b/scripts/generate_qa_summary.py
@@ -1,15 +1,12 @@
- codex/auto-generate-qa-summary.md-per-feature/pr
 
 """Utility for creating a markdown QA summary file for compliance audits."""
 
-main
 import argparse
 import re
 from pathlib import Path
 
 
 def parse_tasks(path: Path):
- codex/auto-generate-qa-summary.md-per-feature/pr
 
     """Parse a markdown task list.
 
@@ -24,7 +21,6 @@ def parse_tasks(path: Path):
         Formatted task strings preserving completion status.
     """
 
- main
     tasks = []
     if not path.is_file():
         return tasks
@@ -32,7 +28,6 @@ def parse_tasks(path: Path):
     task_pattern = re.compile(r"^\s*- \[( |x)\] \d+\.\d+ (.+)")
     with path.open() as f:
         for line in f:
- codex/auto-generate-qa-summary.md-per-feature/pr
             if line.strip().lower().startswith('## tasks'):
                 in_tasks_section = True
                 continue
@@ -52,13 +47,11 @@ def parse_tasks(path: Path):
                 m = task_pattern.match(line)
                 if m:
                     status = "Done" if m.group(1) == "x" else "Todo"
- main
                     tasks.append(f"[{status}] {m.group(2).strip()}")
     return tasks
 
 
 def read_text(path: Path):
- codex/auto-generate-qa-summary.md-per-feature/pr
     if path and path.is_file():
         return path.read_text().strip()
     return ''
@@ -76,7 +69,6 @@ def generate_summary(args):
 def generate_summary(args):
     """Create the QA summary markdown file based on CLI arguments."""
 
- main
     tasks = parse_tasks(args.tasks_file) if args.tasks_file else []
     coverage = read_text(args.test_coverage)
     bugs = read_text(args.bugs_fixed)
@@ -113,7 +105,6 @@ def generate_summary(args):
         output_lines.append(args.cicd_log_url)
         output_lines.append('')
 
- codex/auto-generate-qa-summary.md-per-feature/pr
     Path(args.output).write_text('\n'.join(output_lines))
 
 
@@ -127,7 +118,6 @@ def main():
     """Entry point for the ``generate_qa_summary.py`` command line interface."""
 
     parser = argparse.ArgumentParser(description="Generate qa-summary.md for compliance audits")
- main
     parser.add_argument('--tasks-file', type=Path, help='Path to tasks markdown file')
     parser.add_argument('--qa-reviewers', help='Comma-separated list of QA reviewer names')
     parser.add_argument('--test-coverage', type=Path, help='Path to test coverage results file')


### PR DESCRIPTION
## Summary
- clean README and PRD docs by removing leftover codex markers
- delete stray `main` tokens from docs and scripts
- strip spurious lines from `generate_qa_summary.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c9b0df86c83339838c03dc6ed3c02