### PR TITLE
Fix README repetition and remove stray tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,23 +59,18 @@ You'll now have a well-structured task list, often with tasks and sub-tasks, rea
 ### 4️⃣ Instruct the AI to Work Through Tasks (and Mark Completion)
 
 To ensure methodical progress and allow for verification, we'll use `process-task-list.mdc`. This command instructs the AI to focus on one task at a time and wait for your go-ahead before moving to the next.
-*   **`scripts/generate_qa_summary.py`**: Creates a `qa-summary.md` file summarizing tasks, QA reviewers, test coverage, bugs, and CI/CD logs.
 
 1.  Create or ensure you have the `process-task-list.mdc` file accessible.
-*   **`scripts/generate_qa_summary.py`**: Creates a `qa-summary.md` file summarizing tasks, QA reviewers, test coverage, bugs, and CI/CD logs.
 2.  In Cursor's Agent chat, tell the AI to start with the first task (e.g., `1.1`):
 
     ```
     Please start on task 1.1 and use @process-task-list.mdc
-*   **`scripts/generate_qa_summary.py`**: Creates a `qa-summary.md` file summarizing tasks, QA reviewers, test coverage, bugs, and CI/CD logs.
     ```
     *(Important: You only need to reference `@process-task-list.mdc` for the *first* task. The instructions within it guide the AI for subsequent tasks.)*
-*   **`scripts/generate_qa_summary.py`**: Creates a `qa-summary.md` file summarizing tasks, QA reviewers, test coverage, bugs, and CI/CD logs.
 
     The AI will attempt the task and then prompt you to review.
 
     ![Example of starting on a task with process-task-list.mdc](https://pbs.twimg.com/media/Go6I41KWcAAAlHc?format=jpg&name=medium)
-*   **`scripts/generate_qa_summary.py`**: Creates a `qa-summary.md` file summarizing tasks, QA reviewers, test coverage, bugs, and CI/CD logs.
 
 ### 5️⃣ Review, Approve, and Progress ✅
 
@@ -101,7 +96,6 @@ After merging your changes, run `qa-regression-builder.mdc` to analyze recent lo
 *   **`generate-tasks.mdc`**: Takes a PRD markdown file as input and helps the AI break it down into a detailed, step-by-step implementation task list with embedded QA and security subtasks.
 *   **`process-task-list.mdc`**: Instructs the AI on how to process the generated task list, tackling one task at a time and waiting for your approval before proceeding. This file also checks for QA sign-off and passing security scans before closing tasks.
 *   **`generate-qa-checklist.mdc`**: Builds a feature-specific QA checklist covering accessibility, security scans, and coverage requirements.
-*   **`qa-regression-builder.mdc`**: After a merge, parse logs for repeated errors and suggest regression tests or new tasks.
 *   **`qa-regression-builder.mdc`**: After a merge, parse logs for repeated errors and suggest regression tests or new tasks.
 *   **`scripts/generate_qa_summary.py`**: Creates a `qa-summary.md` file summarizing tasks, QA reviewers, test coverage, bugs, and CI/CD logs.
 

--- a/scripts/generate_qa_summary.py
+++ b/scripts/generate_qa_summary.py
@@ -33,7 +33,6 @@ def parse_tasks(path: Path):
             lower = line.strip().lower()
             if lower.startswith("## tasks"):
                 in_tasks = True
-main
                 continue
             if in_tasks:
                 if line.strip().startswith("##") and not lower.startswith("## tasks"):
@@ -90,7 +89,6 @@ def generate_summary(args):
 
 
     Path(args.output).write_text("\n".join(lines))
- main
 
 
 def main():
@@ -102,7 +100,6 @@ def main():
     parser.add_argument("--bugs-fixed", type=Path, help="Path to bugs found/fixed file")
     parser.add_argument("--cicd-log-url", help="Link to CI/CD logs")
     parser.add_argument("--output", default="qa-summary.md", help="Output markdown file")
- main
 
     args = parser.parse_args()
     generate_summary(args)


### PR DESCRIPTION
## Summary
- clean up repeated lines in README
- remove stray `main` tokens from the QA summary script
- ensure repository tests pass

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683c9fb53b048333b6b02a54b9a8b139